### PR TITLE
[fix] 팔로우 관련 조회에서  @Transactional(readOnly=true) 추가

### DIFF
--- a/src/main/java/com/sparta/followfollowmeproject/follow/service/FollowService.java
+++ b/src/main/java/com/sparta/followfollowmeproject/follow/service/FollowService.java
@@ -20,6 +20,7 @@ public class FollowService {
 	private final UserRepository userRepository;
 
 	// 팔로잉 목록 조회
+	@Transactional(readOnly=true)
 	public List<FollowingListDto> getFollowingList(User follower) {
 		List<Follow> follows = followRepository.findAllByFollower(follower);
 		List<FollowingListDto> followingList = new ArrayList<>();

--- a/src/main/java/com/sparta/followfollowmeproject/post/service/PostService.java
+++ b/src/main/java/com/sparta/followfollowmeproject/post/service/PostService.java
@@ -12,6 +12,7 @@ import com.sparta.followfollowmeproject.post.repository.PostRepository;
 import com.sparta.followfollowmeproject.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -82,6 +83,7 @@ public class PostService {
 
 
     // 팔로우 한 사용자의 게시글만 조회
+    @Transactional(readOnly=true)
     public List<PostResponseDto> getFollowingPosts(User user) {
         // 로그인 한 사용자가 팔로우한 목록 가져오기
         List<Follow> follows = followRepository.findAllByFollower(user);


### PR DESCRIPTION
1. 팔로우 한 사용자의 게시글 조회
2. 팔로우 목록 조회 내용에 @Transactional(readOnly=true) 추가